### PR TITLE
Fix - build and deploy latest test image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,18 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "CommonJS",
+    "module": "ESNext",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
     },
+    "lib": ["ESNext", "DOM"],
     "moduleResolution": "Node",
     "outDir": "dist",
     "importsNotUsedAsValues": "remove",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "incremental": false,
     "strict": true,
     "noPropertyAccessFromIndexSignature": false,
     "skipLibCheck": true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,10 +2,14 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['./src'],
-  splitting: false,
+  format: ['cjs', 'esm'],
+  outDir: 'dist',
   sourcemap: true,
   clean: true,
+  splitting: false,
+  minify: false,
+  skipNodeModulesBundle: true,
   loader: {
-    '.html': 'text',
-  },
+    '.html': 'text'
+  }
 });


### PR DESCRIPTION
Arreglo para que haga el deploy de la imagen del dockerfile cuando ejecutamos `npm run start`

Encontre estos errores a la hora de probar la imagen de prod

```shell
> proyecto-arima-backend@0.0.1 start
> node dist/index.js


node:internal/event_target:1090
  process.nextTick(() => { throw err; });
                           ^
Error: Cannot find module '/<LOCAL_PATH>/backend/dist/lib/worker.js'
    at Function._resolveFilename (node:internal/modules/cjs/loader:1219:15)
    at Function._load (node:internal/modules/cjs/loader:1045:27)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:215:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:158:5)
    at MessagePort.<anonymous> (node:internal/main/worker_thread:185:26)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:816:20)
    at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28) {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v22.5.1
```